### PR TITLE
Update Primary Lumber Uses Chart

### DIFF
--- a/js/species-chart.js
+++ b/js/species-chart.js
@@ -44,12 +44,14 @@ let chart2 = new Chart(myChart2, {
         ]
     },
     options: {
-        title: {
-            text: "Primary Lumber Uses",
-            display: true
-        },
-        legend: {
-            display: false
+        plugins: {
+            title: {
+                text: "Primary Lumber Uses",
+                display: true
+            },
+            legend: {
+                display: false
+            }
         }
     }
 
@@ -71,7 +73,7 @@ let chart3 = new Chart(myChart3, {
             borderColor: "rgba(186, 162, 84, 1)",
             pointBorderColor: "#ffff",
             pointBackgroundColor: "rgba(186, 162, 84, 1)",
-            data: [40, 78, 10, 5]    
+            data: [40, 78, 10, 5]
         },
         {
             label: 'Walnut',
@@ -80,7 +82,7 @@ let chart3 = new Chart(myChart3, {
             borderColor: "rgba(38, 27, 3, 1)",
             pointBorderColor: "#ffff",
             pointBackgroundColor: "rgba(38, 27, 3, 1)",
-            data: [60, 27, 20, 35]    
+            data: [60, 27, 20, 35]
         },
         {
             label: 'Cherry',
@@ -89,7 +91,7 @@ let chart3 = new Chart(myChart3, {
             borderColor: "rgba(179, 94, 34, 1)",
             pointBorderColor: "#ffff",
             pointBackgroundColor: "rgba(179, 94, 34, 1)",
-            data: [30, 40, 50, 90]    
+            data: [30, 40, 50, 90]
         }
 
         ]


### PR DESCRIPTION
Per https://www.chartjs.org/docs/latest/configuration/title.html#example-usage,
chart title configuration is affected via "plugins", which effectively means
that chart.options.title needs to be set through plugins, i.e.,
chart.options.plugins.title.

This change inserts a plugins property between options and title. And also
does the same for legend.

My text editor automatically removes trailing whitespace hence the 
the other diffs in this file.